### PR TITLE
Get rid of broken formatter, best effort to format queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Get rid of `anbt-sql-formatter` dependency since it breaks queries with type casting
+
 ## [0.1.1] - 2025-01-29
 
 - Proper deparsing of all statements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,11 @@ PATH
   remote: .
   specs:
     activerecord-pg-format-db-structure (0.1.1)
-      anbt-sql-formatter (~> 0.1)
       pg_query (~> 6.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    anbt-sql-formatter (0.1.1)
     ast (2.4.2)
     bigdecimal (3.1.9)
     coderay (1.1.3)

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Should be run after other operations that inline alter statements.
 
 Returns an SQL string from raw PgQuery statements.
 
-Relying mostly on `PgQuery.deparse`, but applying some formatting using the [anbt-sql-formatter](https://github.com/sonota88/anbt-sql-formatter) gem on select & insert statements.
+Relying mostly on `PgQuery.deparse`, and does a best effort to add some indentation where possible.
 
 ## Development
 

--- a/activerecord-clean-postgres-db-structure.gemspec
+++ b/activerecord-clean-postgres-db-structure.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "anbt-sql-formatter", "~> 0.1"
   spec.add_dependency "pg_query", "~> 6.0"
 
   # For more information and examples about making a new gem, check out our

--- a/spec/activerecord-pg-format-db-structure/deparser_spec.rb
+++ b/spec/activerecord-pg-format-db-structure/deparser_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Deparser do
 
   describe "#deparse_raw_statement" do
     context "with a select query" do
-      it "returns a formated query using anbt-sql-formatter" do
+      it "returns a formated query" do
         source = +<<~SQL
           SELECT * FROM my_table WHERE 1 = 1;
         SQL
@@ -20,17 +20,28 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Deparser do
 
 
           SELECT
-                  *
-              FROM
-                  my_table
-              WHERE
-                  1 = 1;
+              *
+           FROM my_table WHERE 1 = 1;
+        SQL
+      end
+
+      it "respects type casting" do
+        source = +<<~SQL
+          SELECT '1'::integer;
+        SQL
+
+        expect(formatter.format(source)).to eq(<<~SQL.chomp)
+
+
+          SELECT
+              '1'::int
+          ;
         SQL
       end
     end
 
     context "with an insert statement" do
-      it "returns a formated query using anbt-sql-formatter" do
+      it "returns a formated query" do
         source = +<<~SQL
           INSERT INTO schema_migrations (version) VALUES ('20250124155339'), ('20250134155339') , ('20250144155339');
         SQL
@@ -46,10 +57,27 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Deparser do
           ;
         SQL
       end
+
+      it "also handles insert from select" do
+        source = +<<~SQL
+          INSERT INTO schema_migrations (version) SELECT foo from bar;
+
+        SQL
+
+        expect(formatter.format(source)).to eq(<<~SQL.chomp)
+
+
+
+          INSERT INTO schema_migrations (version) SELECT
+              foo
+           FROM bar
+          ;
+        SQL
+      end
     end
 
     context "with a create view statement" do
-      it "returns a create statement where the body is formatted using anbt-sql-formatter" do
+      it "returns a create statement where the body is formatted" do
         source = +<<~SQL
           CREATE VIEW public.post_stats AS (
             SELECT * FROM public.posts
@@ -61,16 +89,53 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Deparser do
 
           CREATE VIEW public.post_stats AS (
               SELECT
-                      *
-                  FROM
-                      public.posts
+                  *
+               FROM public.posts
+          );
+        SQL
+      end
+
+      it "works with non-select queries" do
+        source = +<<~SQL
+          CREATE VIEW public.post_stats AS (
+            VALUES ('foo')
+          );
+        SQL
+
+        expect(formatter.format(source)).to eq(<<~SQL.chomp)
+
+
+          CREATE VIEW public.post_stats AS (
+              VALUES ('foo')
           );
         SQL
       end
     end
 
+    context "with a CTE" do
+      it "does a best effort at formatting" do
+        source = +<<~SQL
+          WITH my_cte AS (SELECT foo, baz FROM bar)
+          SELECT * from my_cte;
+        SQL
+
+        expect(formatter.format(source)).to eq(<<~SQL.chomp)
+
+
+          WITH my_cte AS (
+              SELECT
+                  foo,
+                  baz
+               FROM bar
+          ) SELECT
+              *
+           FROM my_cte;
+        SQL
+      end
+    end
+
     context "with a create materialized view statement" do
-      it "returns a create statement where the body is formatted using anbt-sql-formatter" do
+      it "returns a create statement where the body is formatted" do
         source = +<<~SQL
           CREATE MATERIALIZED VIEW public.post_stats AS (
             SELECT * FROM public.posts
@@ -82,9 +147,8 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Deparser do
 
           CREATE MATERIALIZED VIEW public.post_stats AS (
               SELECT
-                      *
-                  FROM
-                      public.posts
+                  *
+               FROM public.posts
           );
         SQL
       end

--- a/spec/activerecord-pg-format-db-structure/transforms/move_indices_after_create_table_spec.rb
+++ b/spec/activerecord-pg-format-db-structure/transforms/move_indices_after_create_table_spec.rb
@@ -64,9 +64,8 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Transforms::MoveIndicesAfterCrea
 
         CREATE MATERIALIZED VIEW public.post_stats AS (
             SELECT
-                    *
-                FROM
-                    public.posts
+                *
+             FROM public.posts
         );
         CREATE INDEX index_post_stats_on_score ON public.post_stats USING btree (score);
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ SimpleCov.start
 
 require "activerecord-pg-format-db-structure"
 require "activerecord-pg-format-db-structure/formatter"
+require "pry"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
there's a lot to improve to better handle formatting complex queries with large WHERE clauses and CASE statements, but at least we can guarantee that the formatting doesn't break anything.