### PR TITLE
Rework SQL formatting using PgQuery#scan

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,19 +15,10 @@ Style/StringLiteralsInInterpolation:
 Naming/FileName:
   Enabled: false
 
-Metrics/BlockLength:
+Naming/VariableNumber:
   Enabled: false
 
-Metrics/MethodLength:
-  Enabled: false
-
-Metrics/AbcSize:
-  Enabled: false
-
-Metrics/ClassLength:
-  Enabled: false
-
-Metrics/CyclomaticComplexity:
+Metrics:
   Enabled: false
 
 RSpec/SpecFilePathFormat:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Rework SQL formatting by only adding indentation to deparsed statements
+
 ## [0.1.2] - 2025-01-30
 
 - Get rid of `anbt-sql-formatter` dependency since it breaks queries with type casting

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ ALTER TABLE ONLY public.comments
 
 
 INSERT INTO schema_migrations (version) VALUES
- ('20250124155339')
+  ('20250124155339')
 ;
 ```
 

--- a/lib/activerecord-pg-format-db-structure/deparser.rb
+++ b/lib/activerecord-pg-format-db-structure/deparser.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
 require "pg_query"
+require_relative "indenter"
 
 module ActiveRecordPgFormatDbStructure
   # Returns a list of SQL strings from a list of PgQuery::RawStmt.
   class Deparser
     attr_reader :source
-
-    PRETTY_INDENT_STRING = "    "
 
     def initialize(source)
       @source = source
@@ -15,231 +14,53 @@ module ActiveRecordPgFormatDbStructure
 
     def deparse_raw_statement(raw_statement)
       case raw_statement.to_h
+      in stmt: { insert_stmt: _ }
+        deparse_insert_stmt(raw_statement.stmt.insert_stmt)
       in stmt: { create_stmt: _ }
         deparse_create_stmt(raw_statement.stmt.create_stmt)
       in stmt: { index_stmt: _ }
-        deparse_index_stmt(raw_statement.stmt.index_stmt)
-      in stmt: { alter_table_stmt: _ }
-        deparse_alter_table_stmt(raw_statement.stmt.alter_table_stmt)
-      in stmt: { select_stmt: _ }
-        deparse_select_stmt(raw_statement.stmt.select_stmt)
-      in stmt: { insert_stmt: _ }
-        deparse_insert_statement(raw_statement.stmt.insert_stmt)
-      in stmt: { create_table_as_stmt: _ }
-        deparse_create_table_as_stmt(raw_statement.stmt.create_table_as_stmt)
-      in stmt: { view_stmt: _ }
-        deparse_view_stmt(raw_statement.stmt.view_stmt)
+        deparse_stmt_compact(raw_statement.stmt.index_stmt)
       else
-        "\n#{deparse_stmt(raw_statement.stmt.inner)}"
+        deparse_stmt_generic(raw_statement.stmt.inner)
       end
     end
 
     private
 
-    def deparse_stmt(stmt)
-      "\n#{PgQuery.deparse_stmt(stmt)};"
+    def deparse_stmt_generic(stmt)
+      generic_str = +"\n\n"
+      generic_str << deparse_stmt_and_indent(stmt)
+      generic_str << ";"
+      generic_str
     end
 
-    def deparse_select_stmt(select_stmt)
-      generic_query_str = +"\n\n"
-      generic_query_str << deparse_leaf_select_stmt(select_stmt)
-      generic_query_str << ";"
+    def deparse_stmt_compact(stmt)
+      compact_str = +"\n"
+      compact_str << deparse_stmt(stmt)
+      compact_str << ";"
+      compact_str
     end
 
-    def deparse_index_stmt(index_stmt)
-      deparse_stmt(index_stmt)
-    end
-
-    def deparse_alter_table_stmt(alter_table_stmt)
-      alter_table_str = +"\n\n"
-      alter_table_str << PgQuery.deparse_stmt(
-        PgQuery::AlterTableStmt.new(
-          **alter_table_stmt.to_h,
-          cmds: []
-        )
-      ).chomp(" ")
-
-      alter_table_cmds_str = alter_table_stmt.cmds.map do |cmd|
-        "\n  #{deparse_alter_table_cmd(cmd)}"
-      end.join(",")
-
-      alter_table_str << alter_table_cmds_str
-      alter_table_str << ";"
-      alter_table_str
-    end
-
-    def deparse_alter_table_cmd(cmd)
-      PgQuery.deparse_stmt(
-        PgQuery::AlterTableStmt.new(
-          relation: { relname: "tmp" },
-          cmds: [cmd]
-        )
-      ).gsub(/\AALTER ONLY tmp /, "")
+    def deparse_insert_stmt(stmt)
+      insert_str = +"\n\n\n"
+      insert_str << deparse_stmt_and_indent(stmt)
+      insert_str << "\n;"
+      insert_str
     end
 
     def deparse_create_stmt(create_stmt)
-      placeholder_column = PgQuery::Node.from(
-        PgQuery::ColumnDef.new(
-          colname: "placeholder_column",
-          type_name: {
-            names: [PgQuery::Node.from_string("placeholder_type")]
-          }
-        )
-      )
-
       table_str = "\n\n\n-- Name: #{create_stmt.relation.relname}; Type: TABLE;\n\n"
-      table_str << PgQuery.deparse_stmt(
-        PgQuery::CreateStmt.new(
-          **create_stmt.to_h,
-          table_elts: [placeholder_column]
-        )
-      )
+      table_str << deparse_stmt_and_indent(create_stmt)
       table_str << ";"
-
-      table_columns = create_stmt.table_elts.map do |elt|
-        "\n    #{deparse_table_elt(elt)}"
-      end.join(",")
-      table_columns << "\n"
-
-      table_str[deparse_table_elt(placeholder_column)] = table_columns
-
       table_str
     end
 
-    def deparse_table_elt(elt)
-      PgQuery.deparse_stmt(
-        PgQuery::CreateStmt.new(
-          relation: { relname: "tmp" }, table_elts: [elt]
-        )
-      ).gsub(/\ACREATE TABLE ONLY tmp \((.*)\)\z/, '\1')
+    def deparse_stmt_and_indent(stmt)
+      Indenter.new(deparse_stmt(stmt)).indent
     end
 
-    def deparse_create_table_as_stmt(stmt)
-      create_table_as_stmt_str = +"\n\n"
-      create_table_as_stmt_str << PgQuery.deparse_stmt(
-        PgQuery::CreateTableAsStmt.new(
-          **stmt.to_h,
-          query: PgQuery::Node.from(placeholder_query_stmt)
-        )
-      )
-      create_table_as_stmt_str << ";"
-
-      query_str = +"(\n"
-      query_str << deparse_leaf_select_stmt(stmt.query.select_stmt).gsub(/^/, PRETTY_INDENT_STRING)
-      query_str << "\n)"
-
-      create_table_as_stmt_str[placeholder_query_string] = query_str
-      create_table_as_stmt_str
-    end
-
-    def deparse_view_stmt(stmt)
-      view_stmt_str = +"\n\n"
-      view_stmt_str << PgQuery.deparse_stmt(
-        PgQuery::ViewStmt.new(
-          **stmt.to_h,
-          query: PgQuery::Node.from(placeholder_query_stmt)
-        )
-      )
-      view_stmt_str << ";"
-
-      query_str = +"(\n"
-      query_str << deparse_leaf_select_stmt(stmt.query.select_stmt).gsub(/^/, PRETTY_INDENT_STRING)
-      query_str << "\n)"
-
-      view_stmt_str[placeholder_query_string] = query_str
-      view_stmt_str
-    end
-
-    def deparse_insert_statement(insert_stmt)
-      insert_stmt_str = +"\n\n\n"
-      insert_stmt_str << PgQuery.deparse_stmt(
-        PgQuery::InsertStmt.new(
-          **insert_stmt.to_h,
-          select_stmt: PgQuery::Node.from(placeholder_query_stmt)
-        )
-      )
-      insert_stmt_str << "\n;"
-
-      query_str = if insert_stmt.select_stmt.inner.values_lists.any?
-                    deparse_values_list_select_stmt(insert_stmt.select_stmt.inner)
-                  else
-                    deparse_leaf_select_stmt(insert_stmt.select_stmt.inner)
-                  end
-
-      insert_stmt_str[placeholder_query_string] = query_str
-      insert_stmt_str
-    end
-
-    def deparse_values_list_select_stmt(select_stmt)
-      values_str = +"VALUES\n "
-      values_str << select_stmt.values_lists.map do |values_list|
-        PgQuery.deparse_stmt(PgQuery::SelectStmt.new(values_lists: [values_list])).gsub(/\AVALUES /, "")
-      end.join("\n,")
-      values_str
-    end
-
-    def deparse_leaf_select_stmt(select_stmt) # rubocop:disable Metrics/PerceivedComplexity
-      target_list_placeholder = PgQuery::ResTarget.new(
-        val: { a_const: { sval: { sval: "target_list_placeholder" } } }
-      )
-
-      if select_stmt.with_clause
-        placeholder_with_clause = PgQuery::WithClause.new(
-          **select_stmt.with_clause.to_h,
-          ctes: select_stmt.with_clause.ctes.map do |cte|
-            PgQuery::Node.from(
-              PgQuery::CommonTableExpr.new(
-                **cte.inner.to_h,
-                ctequery: PgQuery::Node.from(placeholder_query_stmt("placeholder_for_#{cte.inner.ctename}_cte"))
-              )
-            )
-          end
-        )
-      end
-
-      select_stmt_str = PgQuery.deparse_stmt(
-        PgQuery::SelectStmt.new(
-          **select_stmt.to_h,
-          with_clause: placeholder_with_clause,
-          target_list: ([PgQuery::Node.from(target_list_placeholder)] if select_stmt.target_list.any?)
-        )
-      )
-
-      if select_stmt.target_list.any?
-        target_list_str = +"\n"
-        target_list_str << select_stmt.target_list.map do |target|
-          deparse_res_target(target.inner).gsub(/^/, PRETTY_INDENT_STRING)
-        end.join(",\n")
-        target_list_str << "\n"
-
-        select_stmt_str[deparse_res_target(target_list_placeholder)] = target_list_str
-      end
-
-      select_stmt.with_clause&.ctes&.each do |cte|
-        cte_str = +"\n"
-        cte_str << deparse_leaf_select_stmt(cte.inner.ctequery.inner).gsub(/^/, PRETTY_INDENT_STRING)
-        cte_str << "\n"
-
-        select_stmt_str["SELECT placeholder_for_#{cte.inner.ctename}_cte"] = cte_str
-      end
-
-      select_stmt_str.gsub!(/ +$/, "")
-
-      select_stmt_str
-    end
-
-    def deparse_res_target(res_target)
-      PgQuery.deparse_stmt(
-        PgQuery::SelectStmt.new(target_list: [PgQuery::Node.from(res_target)])
-      ).gsub(/\ASELECT /, "")
-    end
-
-    def placeholder_query_string(placeholder_name = "placeholder")
-      PgQuery.deparse_stmt(placeholder_query_stmt(placeholder_name))
-    end
-
-    def placeholder_query_stmt(placeholder_name = "placeholder")
-      PgQuery.parse("SELECT #{placeholder_name}").tree.stmts.first.stmt.select_stmt
+    def deparse_stmt(stmt)
+      PgQuery.deparse_stmt(stmt)
     end
   end
 end

--- a/lib/activerecord-pg-format-db-structure/deparser.rb
+++ b/lib/activerecord-pg-format-db-structure/deparser.rb
@@ -18,6 +18,10 @@ module ActiveRecordPgFormatDbStructure
         deparse_insert_stmt(raw_statement.stmt.insert_stmt)
       in stmt: { create_stmt: _ }
         deparse_create_stmt(raw_statement.stmt.create_stmt)
+      in stmt: { view_stmt: _ }
+        deparse_view_stmt(raw_statement.stmt.view_stmt)
+      in stmt: { create_table_as_stmt: _ }
+        deparse_create_table_as_stmt(raw_statement.stmt.create_table_as_stmt)
       in stmt: { index_stmt: _ }
         deparse_stmt_compact(raw_statement.stmt.index_stmt)
       else
@@ -48,9 +52,23 @@ module ActiveRecordPgFormatDbStructure
       insert_str
     end
 
-    def deparse_create_stmt(create_stmt)
-      table_str = "\n\n\n-- Name: #{create_stmt.relation.relname}; Type: TABLE;\n\n"
-      table_str << deparse_stmt_and_indent(create_stmt)
+    def deparse_create_stmt(stmt)
+      table_str = "\n\n\n-- Name: #{stmt.relation.relname}; Type: TABLE;\n\n"
+      table_str << deparse_stmt_and_indent(stmt)
+      table_str << ";"
+      table_str
+    end
+
+    def deparse_view_stmt(stmt)
+      table_str = "\n\n\n-- Name: #{stmt.view.relname}; Type: VIEW;\n\n"
+      table_str << deparse_stmt_and_indent(stmt)
+      table_str << ";"
+      table_str
+    end
+
+    def deparse_create_table_as_stmt(stmt)
+      table_str = "\n\n\n-- Name: #{stmt.into.rel.relname}; Type: MATERIALIZED VIEW;\n\n"
+      table_str << deparse_stmt_and_indent(stmt)
       table_str << ";"
       table_str
     end

--- a/lib/activerecord-pg-format-db-structure/deparser.rb
+++ b/lib/activerecord-pg-format-db-structure/deparser.rb
@@ -69,6 +69,10 @@ module ActiveRecordPgFormatDbStructure
     def deparse_create_table_as_stmt(stmt)
       table_str = "\n\n\n-- Name: #{stmt.into.rel.relname}; Type: MATERIALIZED VIEW;\n\n"
       table_str << deparse_stmt_and_indent(stmt)
+
+      # couldn't find a better solution for this, but probably an OK workaround?
+      table_str.gsub!(/ WITH NO DATA\z/, "\nWITH NO DATA")
+
       table_str << ";"
       table_str
     end

--- a/lib/activerecord-pg-format-db-structure/indenter.rb
+++ b/lib/activerecord-pg-format-db-structure/indenter.rb
@@ -1,0 +1,277 @@
+# frozen_string_literal: true
+
+require "pg_query"
+
+module ActiveRecordPgFormatDbStructure
+  # Inserts newlines and whitespace on a deparsed SQL string
+  class Indenter
+    Token = Data.define(:type, :string)
+
+    # Reserved Keywords
+    ADD = :ADD_P
+    ALTER = :ALTER
+    AND = :AND
+    AS = :AS
+    CASE = :CASE
+    CREATE = :CREATE
+    CROSS = :CROSS
+    DROP = :DROP
+    ELSE = :ELSE
+    END_P = :END_P
+    EXCEPT = :EXCEPT
+    FETCH = :FETCH
+    FOR = :FOR
+    FROM = :FROM
+    GROUP = :GROUP_P
+    HAVING = :HAVING
+    INNER = :INNER
+    INSERT = :INSERT
+    INTERSECT = :INTERSECT
+    JOIN = :JOIN
+    LEFT = :LEFT
+    RIGHT = :RIGHT
+    LIMIT = :LIMIT
+    OFFSET = :OFFSET
+    OR = :OR
+    SELECT = :SELECT
+    TABLE = :TABLE
+    THEN = :THEN
+    UNION = :UNION
+    VALUES = :VALUES
+    VIEW = :VIEW
+    WHEN = :WHEN
+    WHERE = :WHERE
+    WHITESPACE = :WHITESPACE
+    WINDOW = :WINDOW
+    WITH = :WITH
+
+    # ASCII tokens
+    COMMA = :ASCII_44
+    OPEN_PARENS = :ASCII_40
+    CLOSE_PARENS = :ASCII_41
+
+    # Helpers
+    PARENS = :PARENS
+    INDENT_STRING = "  "
+    SELECT_PADDING = "   "
+    TABLE_ELTS = :TABLE_ELTS
+
+    attr_reader :source
+
+    def initialize(source)
+      @source = PgQuery.deparse(PgQuery.parse(source).tree)
+    end
+
+    def indent
+      output = Output.new
+      prev_token = nil
+      tokens.each do |token|
+        output.current_token = token
+        case { current_token: token.type, prev_token: prev_token&.type, inside: output.current_scope_type }
+        in { current_token: CREATE, inside: nil }
+          output.append_scope(type: CREATE)
+          output.append_token
+        in { current_token: ALTER, inside: nil }
+          output.append_scope(type: ALTER, indent: 1)
+          output.append_token
+        in { current_token: INSERT, inside: nil }
+          output.append_scope(type: INSERT, indent: 0)
+          output.append_token
+        in { current_token: VIEW, inside: CREATE }
+          output.append_scope(type: VIEW, indent: 2)
+          output.append_token
+        in { current_token: WITH, inside: CREATE | VIEW | nil }
+          output.append_scope(type: WITH)
+          output.append_token
+        in { current_token: WHITESPACE, prev_token: AS, inside: VIEW }
+          output.append_token
+          output.newline
+          output.apply_indent
+        in { current_token: WHITESPACE, prev_token: COMMA, inside: WITH | SELECT | TABLE_ELTS }
+          output.append_token
+          output.newline
+          output.apply_indent
+        in { current_token: COMMA, inside: INSERT }
+          output.newline
+          output.apply_indent
+          output.append_token
+        in { current_token: SELECT, inside: WITH | INSERT }
+          output.pop_scope
+          output.newline
+          output.apply_indent
+          output.append_token
+          output.append_scope(type: SELECT, indent: 2, padding: SELECT_PADDING)
+        in { current_token: SELECT }
+          output.append_token
+          output.append_scope(type: SELECT, indent: 2, padding: SELECT_PADDING)
+        in { current_token: ALTER | ADD | DROP, inside: ALTER }
+          output.newline
+          output.apply_indent
+          output.append_token
+        in {
+          current_token: CROSS | INNER | LEFT | RIGHT | JOIN => type,
+          inside: SELECT | FROM | JOIN
+        }
+          output.pop_scope
+          output.newline
+          output.apply_indent
+          output.append_token
+          output.append_scope(type:, indent: 0)
+        in {
+          current_token: CROSS | INNER | LEFT | RIGHT | JOIN => type,
+          inside: CROSS | INNER | LEFT | RIGHT
+        }
+          output.append_token
+          output.pop_scope
+          output.append_scope(type:, indent: 0)
+        in {
+          current_token: FROM | WHERE | GROUP | WINDOW | HAVING | LIMIT | OFFSET | FETCH | FOR | UNION |
+            INTERSECT | EXCEPT => token_type
+        }
+          output.pop_scope
+          output.newline
+          output.apply_indent
+          output.append_token
+          output.append_scope(type: token_type, indent: 1)
+        in { current_token: OR | AND, inside: WHERE }
+          output.newline
+          output.apply_indent
+          output.append_token(rjust: 3)
+        in { current_token: CASE }
+          output.append_token
+          output.append_scope(type: CASE, indent: 1, padding: output.current_padding)
+        in { current_token: WHEN | ELSE, inside: CASE }
+          output.newline
+          output.apply_indent
+          output.append_token
+        in { current_token: END_P }
+          output.pop_scope
+          output.newline
+          output.apply_indent
+          output.append_token
+        in { current_token: VALUES, inside: INSERT }
+          output.append_token
+          output.newline
+          output.append_whitespace
+        in { current_token: OPEN_PARENS, inside: CREATE }
+          output.append_token
+          output.newline
+          output.append_scope(type: TABLE_ELTS, indent: 2)
+          output.apply_indent
+        in { current_token: OPEN_PARENS, inside: WITH }
+          output.append_token
+          output.newline
+          output.append_scope(type: PARENS, indent: 2)
+          output.apply_indent
+        in { current_token: OPEN_PARENS, inside: JOIN }
+          output.append_token
+          output.newline
+          output.append_scope(type: PARENS, indent: 2)
+          output.apply_indent
+        in { current_token: OPEN_PARENS }
+          output.append_scope(type: PARENS)
+          output.append_token
+        in { current_token: CLOSE_PARENS, inside: TABLE_ELTS }
+          output.pop_scope
+          output.newline
+          output.apply_indent
+          output.append_token
+        in { current_token: CLOSE_PARENS, inside: PARENS }
+          output.pop_scope
+          output.append_token
+        in { current_token: CLOSE_PARENS }
+          loop do
+            break if output.pop_scope in PARENS | nil
+          end
+          output.newline
+          output.apply_indent
+          output.append_token
+        else
+          output.append_token
+        end
+        prev_token = token
+      end
+      output.to_s
+    end
+
+    private
+
+    def tokens
+      tmp_tokens = []
+      prev_token = Data.define(:end).new(0)
+      PgQuery.scan(source).first.tokens.each do |token|
+        if prev_token.end != token.start
+          tmp_tokens << Token.new(
+            type: WHITESPACE,
+            string: " "
+          )
+        end
+        prev_token = token
+        tmp_tokens << Token.new(
+          type: token.token,
+          string: source[token.start...token.end]
+        )
+      end
+      tmp_tokens
+    end
+
+    # Wrapper that ensures we only append whitespace, and always
+    # append the current token exactly once for each loop.
+    class Output
+      Scope = Data.define(:type, :indent, :padding)
+
+      def initialize
+        @string = +""
+        @scopes = [Scope.new(type: nil, indent: 0, padding: "")]
+        @current_token = nil
+      end
+
+      def to_s
+        # clean extra whitespace at end of string
+        @string.gsub(/\s+\n/, "\n").freeze
+      end
+
+      def current_scope_type
+        @scopes.last.type
+      end
+
+      def current_token=(token)
+        raise "Previous token was not appended!" unless @current_token.nil?
+
+        @current_token = token
+      end
+
+      def append_scope(type:, indent: 0, padding: "")
+        @scopes << Scope.new(type:, indent:, padding:)
+      end
+
+      def current_padding
+        @scopes.last.padding
+      end
+
+      def pop_scope
+        @scopes.pop.type
+      end
+
+      def newline
+        @string << "\n"
+      end
+
+      def append_whitespace
+        @string << " "
+      end
+
+      def apply_indent
+        @string << (INDENT_STRING * @scopes.sum(&:indent))
+        @string << @scopes.last.padding
+      end
+
+      def append_token(rjust: 0)
+        raise "Token was already appended!" if @current_token.nil?
+
+        @string << @current_token.string.rjust(rjust)
+        @current_token = nil
+      end
+    end
+  end
+end

--- a/lib/activerecord-pg-format-db-structure/indenter.rb
+++ b/lib/activerecord-pg-format-db-structure/indenter.rb
@@ -29,10 +29,11 @@ module ActiveRecordPgFormatDbStructure
     INTERSECT = :INTERSECT
     JOIN = :JOIN
     LEFT = :LEFT
-    RIGHT = :RIGHT
     LIMIT = :LIMIT
     OFFSET = :OFFSET
     OR = :OR
+    ORDER = :ORDER
+    RIGHT = :RIGHT
     SELECT = :SELECT
     TABLE = :TABLE
     THEN = :THEN
@@ -125,7 +126,7 @@ module ActiveRecordPgFormatDbStructure
           output.pop_scope
           output.append_scope(type:, indent: 0)
         in {
-          current_token: FROM | WHERE | GROUP | WINDOW | HAVING | LIMIT | OFFSET | FETCH | FOR | UNION |
+          current_token: FROM | WHERE | GROUP | ORDER | WINDOW | HAVING | LIMIT | OFFSET | FETCH | FOR | UNION |
             INTERSECT | EXCEPT => token_type
         }
           output.pop_scope

--- a/spec/activerecord-pg-format-db-structure/deparser_spec.rb
+++ b/spec/activerecord-pg-format-db-structure/deparser_spec.rb
@@ -208,6 +208,7 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Deparser do
                   LEFT OUTER JOIN public.main_users ON main_users.id = user_comments.main_user_id
                   WHERE main_users.type::text = 'first'::text
                   GROUP BY mains_1.id, mains_1.comment_id
+                  ORDER BY mains_1.id
               ),
               second_cte AS (
                   SELECT mains_1.id AS main_id,
@@ -245,6 +246,7 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Deparser do
                   LEFT JOIN public.main_users ON main_users.id = user_comments.main_user_id
                   WHERE main_users.type::text = 'first'::text
                   GROUP BY mains_1.id, mains_1.comment_id
+                  ORDER BY mains_1.id
               ),
               second_cte AS (
                   SELECT mains_1.id AS main_id,

--- a/spec/activerecord-pg-format-db-structure/deparser_spec.rb
+++ b/spec/activerecord-pg-format-db-structure/deparser_spec.rb
@@ -194,6 +194,26 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Deparser do
               FROM public.posts;
         SQL
       end
+
+      it "deals with WITH NO DATA suffix" do
+        source = +<<~SQL
+          CREATE MATERIALIZED VIEW public.post_stats AS (
+            SELECT * FROM public.posts
+          ) WITH NO DATA;
+        SQL
+
+        expect(formatter.format(source)).to eq(<<~SQL.chomp)
+
+
+
+          -- Name: post_stats; Type: MATERIALIZED VIEW;
+
+          CREATE MATERIALIZED VIEW public.post_stats AS
+              SELECT *
+              FROM public.posts
+          WITH NO DATA;
+        SQL
+      end
     end
 
     context "with some complex examples" do

--- a/spec/activerecord-pg-format-db-structure/deparser_spec.rb
+++ b/spec/activerecord-pg-format-db-structure/deparser_spec.rb
@@ -126,6 +126,9 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Deparser do
         expect(formatter.format(source)).to eq(<<~SQL.chomp)
 
 
+
+          -- Name: post_stats; Type: VIEW;
+
           CREATE VIEW public.post_stats AS
               SELECT *
               FROM public.posts;
@@ -141,6 +144,9 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Deparser do
 
         expect(formatter.format(source)).to eq(<<~SQL.chomp)
 
+
+
+          -- Name: post_stats; Type: VIEW;
 
           CREATE VIEW public.post_stats AS
               VALUES ('foo');
@@ -179,6 +185,9 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Deparser do
 
         expect(formatter.format(source)).to eq(<<~SQL.chomp)
 
+
+
+          -- Name: post_stats; Type: MATERIALIZED VIEW;
 
           CREATE MATERIALIZED VIEW public.post_stats AS
               SELECT *
@@ -223,6 +232,9 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Deparser do
 
         expect(formatter.format(source)).to eq(<<~SQL.chomp)
 
+
+
+          -- Name: my_bigg_aggregated_view; Type: VIEW;
 
           CREATE VIEW public.my_bigg_aggregated_view AS
               WITH first_cte AS (

--- a/spec/activerecord-pg-format-db-structure/formatter_spec.rb
+++ b/spec/activerecord-pg-format-db-structure/formatter_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Formatter do
 
 
         INSERT INTO schema_migrations (version) VALUES
-         ('20250124155339')
+          ('20250124155339')
         ;
       SQL
     end

--- a/spec/activerecord-pg-format-db-structure/indenter_spec.rb
+++ b/spec/activerecord-pg-format-db-structure/indenter_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe ActiveRecordPgFormatDbStructure::Indenter do
+  describe described_class::Output do
+    describe "#current_token=" do
+      it "ensures the previous token was appended before setting the next one", :aggregate_failures do
+        output = described_class.new
+        output.current_token = make_token(type: :SELECT, string: "SELECT")
+        expect do
+          output.current_token = make_token(type: :SELECT, string: "SELECT")
+        end.to raise_error("Previous token was not appended!")
+
+        output.append_token
+        expect do
+          output.current_token = make_token(type: :SELECT, string: "SELECT")
+        end.not_to raise_error
+      end
+    end
+
+    describe "#append_token" do
+      it "ensures the current token is only appended once" do
+        output = described_class.new
+        output.current_token = make_token(type: :SELECT, string: "SELECT")
+        output.append_token
+        expect do
+          output.append_token
+        end.to raise_error("Token was already appended!")
+      end
+    end
+  end
+
+  def make_token(type:, string:)
+    ActiveRecordPgFormatDbStructure::Indenter::Token.new(type:, string:)
+  end
+end

--- a/spec/activerecord-pg-format-db-structure/transforms/group_alter_table_statements_spec.rb
+++ b/spec/activerecord-pg-format-db-structure/transforms/group_alter_table_statements_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Transforms::GroupAlterTableState
 
 
         INSERT INTO schema_migrations (version) VALUES
-         ('20250124155339')
+          ('20250124155339')
         ;
       SQL
     end
@@ -178,7 +178,7 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Transforms::GroupAlterTableState
 
 
         INSERT INTO schema_migrations (version) VALUES
-         ('20250124155339')
+          ('20250124155339')
         ;
       SQL
     end

--- a/spec/activerecord-pg-format-db-structure/transforms/inline_constraints_spec.rb
+++ b/spec/activerecord-pg-format-db-structure/transforms/inline_constraints_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Transforms::InlineConstraints do
 
 
         INSERT INTO schema_migrations (version) VALUES
-         ('20250124155339')
+          ('20250124155339')
         ;
       SQL
     end

--- a/spec/activerecord-pg-format-db-structure/transforms/inline_foreign_keys_spec.rb
+++ b/spec/activerecord-pg-format-db-structure/transforms/inline_foreign_keys_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Transforms::InlineForeignKeys do
 
 
         INSERT INTO schema_migrations (version) VALUES
-         ('20250124155339')
+          ('20250124155339')
         ;
       SQL
     end

--- a/spec/activerecord-pg-format-db-structure/transforms/inline_primary_keys_spec.rb
+++ b/spec/activerecord-pg-format-db-structure/transforms/inline_primary_keys_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Transforms::InlinePrimaryKeys do
 
 
         INSERT INTO schema_migrations (version) VALUES
-         ('20250124155339')
+          ('20250124155339')
         ;
       SQL
     end

--- a/spec/activerecord-pg-format-db-structure/transforms/inline_serials_spec.rb
+++ b/spec/activerecord-pg-format-db-structure/transforms/inline_serials_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Transforms::InlineSerials do
 
 
         INSERT INTO schema_migrations (version) VALUES
-         ('20250124155339')
+          ('20250124155339')
         ;
       SQL
     end

--- a/spec/activerecord-pg-format-db-structure/transforms/move_indices_after_create_table_spec.rb
+++ b/spec/activerecord-pg-format-db-structure/transforms/move_indices_after_create_table_spec.rb
@@ -62,11 +62,9 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Transforms::MoveIndicesAfterCrea
             score int NOT NULL
         );
 
-        CREATE MATERIALIZED VIEW public.post_stats AS (
-            SELECT
-                *
-             FROM public.posts
-        );
+        CREATE MATERIALIZED VIEW public.post_stats AS
+            SELECT *
+            FROM public.posts;
         CREATE INDEX index_post_stats_on_score ON public.post_stats USING btree (score);
 
 
@@ -81,7 +79,7 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Transforms::MoveIndicesAfterCrea
 
 
         INSERT INTO schema_migrations (version) VALUES
-         ('20250124155339')
+          ('20250124155339')
         ;
       SQL
     end

--- a/spec/activerecord-pg-format-db-structure/transforms/move_indices_after_create_table_spec.rb
+++ b/spec/activerecord-pg-format-db-structure/transforms/move_indices_after_create_table_spec.rb
@@ -62,6 +62,9 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Transforms::MoveIndicesAfterCrea
             score int NOT NULL
         );
 
+
+        -- Name: post_stats; Type: MATERIALIZED VIEW;
+
         CREATE MATERIALIZED VIEW public.post_stats AS
             SELECT *
             FROM public.posts;

--- a/spec/activerecord-pg-format-db-structure/transforms/remove_comments_on_extensions_spec.rb
+++ b/spec/activerecord-pg-format-db-structure/transforms/remove_comments_on_extensions_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe ActiveRecordPgFormatDbStructure::Transforms::RemoveCommentsOnExte
 
 
         INSERT INTO schema_migrations (version) VALUES
-         ('20250124155339')
+          ('20250124155339')
         ;
       SQL
     end


### PR DESCRIPTION
try a completely new approach that should be more resilient. The idea is to have an Indenter that only adds extra whitespace on top of deparsed string, guaranteeing there will be no syntax error.

this is a slightly naive but quite simple approach that should deal with the 99% case pretty well, and deals gracefully with the rest.