### PR TITLE
Remove skip validation setting when inlining constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Remove no-op `NOT VALID` setting when inlining constraints
+
 ## [0.3.0] - 2025-03-15
 
 - Introduce StatementAppender for better spacing between statements

--- a/README.md
+++ b/README.md
@@ -347,7 +347,9 @@ sequence indeed has default settings.
 
 ### InlineConstraints
 
-Inline non-foreign key constraints into table declaration
+Inline non-foreign key constraints into table declaration.
+
+Note that this also remove the `NOT VALID` setting if present, since that's a no-op when the constraint is created at the same time as the table.
 
 ### MoveIndicesAfterCreateTable
 

--- a/lib/activerecord-pg-format-db-structure/transforms/inline_constraints.rb
+++ b/lib/activerecord-pg-format-db-structure/transforms/inline_constraints.rb
@@ -64,7 +64,7 @@ module ActiveRecordPgFormatDbStructure
 
       def add_constraint!(raw_statement, constraint)
         raw_statement.stmt.create_stmt.table_elts << PgQuery::Node.from(
-          PgQuery::Constraint.new(constraint)
+          PgQuery::Constraint.new(constraint.merge(skip_validation: nil))
         )
       end
     end


### PR DESCRIPTION
when inlining a constraint it get created at the same time as the table, so there's never any row to be validated. This makes the `NOT VALID` option a no-op.

Since it's a no-op when inlined, it also leads to a diff when doing a schema load from the generated structure.sql, since the `NOT VALID` gets dropped.

So let's be pro-active about it, and just get rid of it as soon as the constraint gets inlined.